### PR TITLE
Adding 'Relation' class that enables dynamic sql conditions

### DIFF
--- a/lib/active_record.rb
+++ b/lib/active_record.rb
@@ -1,4 +1,5 @@
 module ActiveRecord
   autoload :Base, "active_record/base"
   autoload :ConnectionAdapter, "active_record/connection_adapter"
+  autoload :Relation, "active_record/relation"
 end

--- a/lib/active_record/base.rb
+++ b/lib/active_record/base.rb
@@ -42,7 +42,11 @@ module ActiveRecord
     end
 
     def self.all
-      find_by_sql("SELECT * FROM #{table_name}")
+      Relation.new(self)
+    end
+
+    def self.where(*args)
+      all.where(*args)
     end
   end
 end

--- a/lib/active_record/relation.rb
+++ b/lib/active_record/relation.rb
@@ -1,0 +1,47 @@
+module ActiveRecord
+  class Relation
+    def initialize(klass)
+      @klass = klass
+      @where_values = []
+    end
+
+    def where!(condition)
+      @where_values += [condition]
+      self
+    end
+
+    def where(condition)
+      clone.where!(condition)
+    end
+
+    def to_sql
+      sql = "SELECT * FROM #{@klass.table_name}"
+
+      if @where_values.any?
+        sql += " WHERE " + @where_values.join(" AND ")
+      end
+
+      sql
+    end
+
+    def records
+      @records ||= @klass.find_by_sql(to_sql)
+    end
+
+    def first
+      records.first
+    end
+
+    def each(&block)
+      records.each(&block)
+    end
+
+    def count
+      records.count
+    end
+
+    def last
+      records.last
+    end
+  end
+end

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe ActiveRecord do
   before do
     Post.establish_connection(database: "#{__dir__}/pastry-blog/db/development.sqlite3")
   end
-  
-  describe 'initialization' do 
+
+  describe 'initialization'
     context 'invoking active record' do
       it 'creates a new post' do
         expect(new_post.id).to eq 1
@@ -19,7 +19,7 @@ RSpec.describe ActiveRecord do
       end
     end
   end
-  
+
   describe 'testing sqlite connection' do
     context 'running a sql query' do
       let(:rows) { Post.connection.execute("SELECT * FROM posts") }
@@ -32,23 +32,29 @@ RSpec.describe ActiveRecord do
       end
     end
   end
-  describe 'loading records from database' do
-    context 'querying for a record' do
+  describe 'searching for records from database' do
+    context 'finding a record based on the id' do
       let(:post1) { (Post.find(1)) }
 
-      it 'brings back results of said record' do
+      it 'brings back the record row' do
         expect(post1.id).to eq 1
         expect(post1.title).to eq('Blueberry Muffins')
       end
     end
 
-    context 'querying for all records' do
+    context 'searching for all records' do
       let(:all_posts) { (Post.all)}
 
       it 'brings back all records' do
         expect(all_posts).to be_kind_of(Array)
         expect(all_posts.count).to eq 2
         expect(all_posts.last.id).to eq 2
+      end
+    end
+
+    context 'searching for records based on specific parameters' do
+      it 'brings record(s)' do
+        
       end
     end
   end

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ActiveRecord do
     Post.establish_connection(database: "#{__dir__}/pastry-blog/db/development.sqlite3")
   end
 
-  describe 'initialization'
+  describe 'initialization' do
     context 'invoking active record' do
       it 'creates a new post' do
         expect(new_post.id).to eq 1
@@ -46,15 +46,20 @@ RSpec.describe ActiveRecord do
       let(:all_posts) { (Post.all)}
 
       it 'brings back all records' do
-        expect(all_posts).to be_kind_of(Array)
+        expect(all_posts).to be_kind_of(ActiveRecord::Relation)
         expect(all_posts.count).to eq 2
         expect(all_posts.last.id).to eq 2
       end
     end
 
     context 'searching for records based on specific parameters' do
+      let(:relation) { Post.where("id = 2").where("title IS NOT NULL") }
+      let(:post2) { relation.first } 
+      let(:native_sql) { "SELECT * FROM posts WHERE id = 2 AND title IS NOT NULL" }
       it 'brings record(s)' do
-        
+        expect(relation).not_to be nil
+        expect(post2.id).to eq 2
+        expect(native_sql).to eq(relation.to_sql)
       end
     end
   end


### PR DESCRIPTION
In the PR, I've:
- created a new class called Relation to handle dynamic conditions of an SQL query, like 'WHERE'
- added the .where method
- added the .first method
- added the .last method
- modified the .all method